### PR TITLE
Make input properties file path configurable.

### DIFF
--- a/src/erlmld_runner.erl
+++ b/src/erlmld_runner.erl
@@ -67,6 +67,13 @@ runner_params(StreamType) ->
     {Pathname, filename:dirname(Pathname)}.
 
 
+input_properties_file_path() ->
+    case application:get_env(erlmld, properties_file_path) of
+        {ok, Val} -> Val;
+        _ -> priv_path("mld.properties.in")
+    end.
+
+
 priv_path(Filename) ->
     Priv = code:priv_dir(erlmld),
     lists:flatten(filename:join(Priv, Filename)).
@@ -80,7 +87,7 @@ tempdir_path(Filename) ->
 %% like "$TMPDIR/erlmld/erlmld.X.properties", where X is either "default" or the
 %% app_suffix value, and return that populated pathname.
 build_properties(#{app_suffix := AppSuffix} = Opts) ->
-    Input = priv_path("mld.properties.in"),
+    Input = input_properties_file_path(),
     Output = tempdir_path("erlmld." ++ atom_to_list(case AppSuffix of
                                                         undefined -> default;
                                                         _ -> AppSuffix


### PR DESCRIPTION
This allows importing custom properties template file by specifying its path in `properties_file_path` env var. The app falls back to the original template file if the variable has not been set.

One of the use cases is to apply a file with configuration keys which should not make their way to production system. E.g. 
```
kinesisEndpoint = http://127.0.0.1:8000
dynamoDBEndpoint = http://127.0.0.1:8000
```
to override original AWS endpoints and point KCL to DynamoDB local when running tests.